### PR TITLE
update build instructions

### DIFF
--- a/src/compile
+++ b/src/compile
@@ -1,1 +1,1 @@
-g++ -g -O2 wayland-proxy.cpp main.cpp -o wayland-proxy
+c++ -std=gnu++17 -g -O2 wayland-proxy.cpp main.cpp -o wayland-proxy -pthread


### PR DESCRIPTION
Use c++ instead of g++ which makes the instructions portable (build works perfectly fine with clang++ tested on FreeBSD with clang 17)

Add standard definition, needed for atomic, which makes it buildable with gcc 9 (tested on ubuntu 20.04)

Add missing pthread