### PR TITLE
portability: remove POLLOUT test on non connected socket

### DIFF
--- a/src/wayland-proxy.cpp
+++ b/src/wayland-proxy.cpp
@@ -326,11 +326,6 @@ struct pollfd* ProxiedConnection::LoadPollFd(struct pollfd* aPfds) {
 }
 
 bool ProxiedConnection::ConnectToCompositor() {
-  if (!(mCompositorFlags & POLLOUT)) {
-    // Try again later
-    return true;
-  }
-
   struct sockaddr_un addr = {};
   addr.sun_family = AF_UNIX;
   strcpy(addr.sun_path, sWaylandDisplay);


### PR DESCRIPTION
While on linux is appears that a non connected sockets can get a POLLOUT event via poll(2), the manpage clearly state that this should be only tested on a connected socket(2). the behaviour on a non connected socket do differ accross systems (FreeBSD do not behave the same here for example) while the behaviour is the same, defined and standardized on connected sockets.

Now the code will directly try to connect to the compositor socket right after creating the socket(2) and not go for another round of poll(2).

Tested on Linux (ubuntu 20.04) and FreeBSD (15-CURRENT)